### PR TITLE
Add .zshrc as source, if reading in someone else's dotfiles

### DIFF
--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -1552,7 +1552,7 @@ builtin setopt noaliases
     else
         reply=(
             $dname/*.plugin.zsh $dname/*.zsh $dname/*.sh
-            $dname/*.zsh-theme
+            $dname/*.zsh-theme $dname/.zshrc
         )
     fi
 }

--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -1552,7 +1552,7 @@ builtin setopt noaliases
     else
         reply=(
             $dname/*.plugin.zsh $dname/*.zsh $dname/*.sh
-            $dname/*.zsh-theme $dname/.zshrc
+            $dname/*.zsh-theme $dname/.zshrc(N)
         )
     fi
 }


### PR DESCRIPTION
Some people make their entire dotfiles available on github, with .zshrc as an entry point, and it's nice to treat the entire setup as one large plugin; this allows zplugin to read in their setup with no changes to their repo.